### PR TITLE
feat: Match withRouter props signature for route components

### DIFF
--- a/src/classic/RelayRouteRenderer.js
+++ b/src/classic/RelayRouteRenderer.js
@@ -95,7 +95,7 @@ class RelayRouteRenderer extends React.Component {
     delete ownProps.readyState;
     delete ownProps.runQueries;
 
-    const { route } = match;
+    const { route, router } = match;
 
     // The render function must be bound here to correctly trigger updates in
     // Relay.ReadyStateRenderer.
@@ -107,14 +107,16 @@ class RelayRouteRenderer extends React.Component {
           return undefined;
         }
 
-        return <Component {...match} {...ownProps} {...props} />;
+        return (
+          <Component match={match} router={router} {...ownProps} {...props} />
+        );
       }
 
       return route.render({
         ...renderArgs,
         match,
         Component,
-        props: props && { ...match, ...ownProps, ...props },
+        props: props && { match, router, ...ownProps, ...props },
         ownProps,
       });
     }

--- a/src/modern/renderElement.js
+++ b/src/modern/renderElement.js
@@ -13,7 +13,7 @@ export default function renderElement({
   resolving, // Whether it's safe to throw a RedirectException or an HttpError.
   /* eslint-enable react/prop-types */
 }) {
-  const { route } = match;
+  const { route, router } = match;
   const { error, props } = readyState;
 
   if (!route.render) {
@@ -31,14 +31,14 @@ export default function renderElement({
       return null;
     }
 
-    return <Component {...match} {...props} />;
+    return <Component match={match} router={router} {...props} />;
   }
 
   return route.render({
     ...readyState,
     match,
     Component: isComponentResolved ? Component : null,
-    props: props && { ...match, ...props },
+    props: props && { match, router, ...props },
     resolving,
   });
 }

--- a/test/classic/Resolver.test.js
+++ b/test/classic/Resolver.test.js
@@ -40,8 +40,8 @@ describe('Resolver', () => {
       },
     });
 
-    function WidgetChildren({ first, second, third, route }) {
-      expect(route).toBeTruthy();
+    function WidgetChildren({ first, second, third, match }) {
+      expect(match.route).toBeTruthy();
 
       return (
         <div>
@@ -213,7 +213,8 @@ describe('Resolver', () => {
         });
 
         it('should have router props', () => {
-          expect(renderArgs.props.route).toBeDefined();
+          expect(renderArgs.props.match).toBeDefined();
+          expect(renderArgs.props.match.route).toBeDefined();
           expect(renderArgs.match).toBeDefined();
           expect(renderArgs.match.route).toBeDefined();
           expect(renderArgs.Component).toBe(WidgetParentContainer);

--- a/test/modern/Resolver.test.js
+++ b/test/modern/Resolver.test.js
@@ -37,8 +37,8 @@ describe('Resolver', () => {
       `,
     );
 
-    function WidgetChildren({ first, second, third, route }) {
-      expect(route).toBeTruthy();
+    function WidgetChildren({ first, second, third, match }) {
+      expect(match.route).toBeTruthy();
 
       return (
         <div>
@@ -196,7 +196,8 @@ describe('Resolver', () => {
         });
 
         it('should have router props', () => {
-          expect(renderArgs.props.route).toBeDefined();
+          expect(renderArgs.props.match).toBeDefined();
+          expect(renderArgs.props.match.route).toBeDefined();
           expect(renderArgs.match).toBeDefined();
           expect(renderArgs.match.route).toBeDefined();
           expect(renderArgs.Component).toBe(WidgetParentContainer);


### PR DESCRIPTION
BREAKING CHANGE: Route components no longer receive spread-out match.

Addresses https://github.com/4Catalyzer/found/issues/229