### PR TITLE
Prevent lastQuerySubscriptions reference

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -139,7 +139,7 @@ export default class Resolver {
       }
     });
 
-    this.lastQuerySubscriptions = querySubscriptions;
+    this.lastQuerySubscriptions = [...querySubscriptions];
 
     return querySubscriptions;
   }


### PR DESCRIPTION
Prevent this.lastQuerySubscriptions referencing to previously created querySubscriptions

https://github.com/4Catalyzer/found/issues/385#issuecomment-528324661