### PR TITLE
Pass resolving to component when rendering

### DIFF
--- a/src/renderElement.js
+++ b/src/renderElement.js
@@ -30,7 +30,7 @@ export default function renderElement({
       return null;
     }
 
-    return <Component match={match} router={router} {...props} />;
+    return <Component match={match} router={router} resolving={resolving} {...props} />;
   }
 
   return route.render({


### PR DESCRIPTION
At the moment the only way to get access to the resolving variable is to replace the `Component` prop with a `render` prop. This can be a lot of overhead for a simple route, so passing this variable in as a prop to the component should make the API easier to use and more consistent with what render receives.